### PR TITLE
[codex] Improve simulator build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /tmp/
 sim/build/
 sim/build-asan/
+sim/build-*/
+sim/local-deps/
 *.log
 *.tmp
 *.bak

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -873,6 +873,7 @@
 - 期待結果: 実機描画と PC 描画を差し替え可能な構造になっており、PC 上でも 320x240 の仮想画面で主要画面の表示と最低限の操作確認ができる
 - 実際の結果: 現状は CoreS3 実機前提の構成で、描画と入力が実機依存コードに寄っているため PC シミュレータ対応が難しい
 - 対応メモ: GitHub issue #70。目的は完全な M5 エミュレータではなく、アプリロジックと描画/入力実装を分離して実機描画と PC 描画を差し替え可能にすること。対象は Renderer 抽象、実機用 Renderer、PC 用 Renderer、320x240 仮想画面、最低限のマウス/キーボード入力、実機ビルドと PC ビルドの分離整理。音声やセンサーの完全再現は対象外
+- 進捗メモ: `sim/CMakeLists.txt` で `ArduinoJson` の探索順を整理し、`.pio/libdeps` / `ARDUINOJSON_ROOT` / `FetchContent` の順で解決できるようにした。`SDL2` / `SDL2_image` / `SDL2_ttf` も config package 優先で検出し、足りない依存は明示エラーにした。`sim/bootstrap.sh` と `sim/CMakePresets.json` を追加し、Apple Silicon では `./bootstrap.sh macos-arm64 && cmake --build --preset macos-arm64` で再現できるようにした
 - 設計メモ:
   - 中心構造は `Input -> update(state, input) -> render(state, renderer)` に寄せる
   - 共通コードは `AppState`、画面定義、UI ロジック、描画命令生成に集約する

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(PokemonCollectionSimulator LANGUAGES CXX)
 
+include(FetchContent)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -8,19 +10,92 @@ if(APPLE AND NOT DEFINED CMAKE_OSX_ARCHITECTURES)
   set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "macOS architectures" FORCE)
 endif()
 
-find_package(SDL2 REQUIRED)
-find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
-  HINTS /opt/homebrew/opt/sdl2_ttf/include/SDL2
+set(SDL2_PREFIX_HINTS
+  /opt/homebrew/opt/sdl2
+  /opt/homebrew/opt/sdl2_image
+  /opt/homebrew/opt/sdl2_ttf
 )
-find_library(SDL2_TTF_LIBRARY SDL2_ttf
-  HINTS /opt/homebrew/opt/sdl2_ttf/lib
+
+set(ARDUINOJSON_ROOT "" CACHE PATH "Path to an ArduinoJson checkout or install root")
+option(POKEMONCOLLECTION_SIM_FETCH_ARDUINOJSON "Fetch ArduinoJson automatically when it is not installed locally" ON)
+
+set(ARDUINOJSON_SEARCH_PATHS)
+if(ARDUINOJSON_ROOT)
+  list(APPEND ARDUINOJSON_SEARCH_PATHS
+    "${ARDUINOJSON_ROOT}"
+    "${ARDUINOJSON_ROOT}/src"
+  )
+endif()
+
+file(GLOB ARDUINOJSON_PIO_CANDIDATES
+  "${CMAKE_CURRENT_SOURCE_DIR}/../.pio/libdeps/*/ArduinoJson/src"
 )
-find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
-  HINTS /opt/homebrew/opt/sdl2_image/include/SDL2
+list(APPEND ARDUINOJSON_SEARCH_PATHS
+  "${CMAKE_CURRENT_SOURCE_DIR}/local-deps/ArduinoJson"
+  "${CMAKE_CURRENT_SOURCE_DIR}/local-deps/ArduinoJson/src"
+  ${ARDUINOJSON_PIO_CANDIDATES}
+  "${CMAKE_CURRENT_SOURCE_DIR}/../.pio/libdeps/m5stack-cores3/ArduinoJson/src"
+  "$ENV{HOME}/.platformio/lib/ArduinoJson/src"
 )
-find_library(SDL2_IMAGE_LIBRARY SDL2_image
-  HINTS /opt/homebrew/opt/sdl2_image/lib
+
+find_path(ARDUINOJSON_INCLUDE_DIR ArduinoJson.h
+  HINTS ${ARDUINOJSON_SEARCH_PATHS}
+  PATH_SUFFIXES src
 )
+
+if(NOT ARDUINOJSON_INCLUDE_DIR)
+  if(POKEMONCOLLECTION_SIM_FETCH_ARDUINOJSON)
+    message(STATUS "ArduinoJson.h was not found locally. Fetching ArduinoJson for sim build.")
+    FetchContent_Declare(
+      arduinojson
+      GIT_REPOSITORY https://github.com/bblanchon/ArduinoJson.git
+      GIT_TAG v7.4.2
+      GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(arduinojson)
+    set(ARDUINOJSON_INCLUDE_DIR "${arduinojson_SOURCE_DIR}/src")
+  else()
+    message(FATAL_ERROR
+      "ArduinoJson.h was not found. Install PlatformIO dependencies with "
+      "'pio run -e m5stack-cores3', pass -DARDUINOJSON_ROOT=/path/to/ArduinoJson, "
+      "or enable -DPOKEMONCOLLECTION_SIM_FETCH_ARDUINOJSON=ON."
+    )
+  endif()
+endif()
+
+find_package(SDL2 REQUIRED CONFIG HINTS ${SDL2_PREFIX_HINTS})
+find_package(SDL2_ttf QUIET CONFIG HINTS ${SDL2_PREFIX_HINTS})
+find_package(SDL2_image QUIET CONFIG HINTS ${SDL2_PREFIX_HINTS})
+
+if(NOT TARGET SDL2_ttf::SDL2_ttf)
+  find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+    HINTS /opt/homebrew/opt/sdl2_ttf/include/SDL2
+  )
+  find_library(SDL2_TTF_LIBRARY SDL2_ttf
+    HINTS /opt/homebrew/opt/sdl2_ttf/lib
+  )
+  if(NOT SDL2_TTF_INCLUDE_DIR OR NOT SDL2_TTF_LIBRARY)
+    message(FATAL_ERROR
+      "SDL2_ttf was not found. Install it first. On macOS/Homebrew, run "
+      "'brew install sdl2_ttf'."
+    )
+  endif()
+endif()
+
+if(NOT TARGET SDL2_image::SDL2_image)
+  find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+    HINTS /opt/homebrew/opt/sdl2_image/include/SDL2
+  )
+  find_library(SDL2_IMAGE_LIBRARY SDL2_image
+    HINTS /opt/homebrew/opt/sdl2_image/lib
+  )
+  if(NOT SDL2_IMAGE_INCLUDE_DIR OR NOT SDL2_IMAGE_LIBRARY)
+    message(FATAL_ERROR
+      "SDL2_image was not found. Install it first. On macOS/Homebrew, run "
+      "'brew install sdl2_image'."
+    )
+  endif()
+endif()
 
 add_executable(pokemoncollection_sim
   main.cpp
@@ -49,15 +124,31 @@ target_compile_definitions(pokemoncollection_sim PRIVATE
 
 target_include_directories(pokemoncollection_sim PRIVATE
   ${SDL2_INCLUDE_DIRS}
-  ${SDL2_TTF_INCLUDE_DIR}
-  ${SDL2_IMAGE_INCLUDE_DIR}
+  ${ARDUINOJSON_INCLUDE_DIR}
   include
   ../include
-  ../.pio/libdeps/m5stack-cores3/ArduinoJson/src
 )
 
+if(SDL2_TTF_INCLUDE_DIR)
+  target_include_directories(pokemoncollection_sim PRIVATE ${SDL2_TTF_INCLUDE_DIR})
+endif()
+
+if(SDL2_IMAGE_INCLUDE_DIR)
+  target_include_directories(pokemoncollection_sim PRIVATE ${SDL2_IMAGE_INCLUDE_DIR})
+endif()
+
 target_link_libraries(pokemoncollection_sim PRIVATE
-  ${SDL2_LIBRARIES}
-  ${SDL2_TTF_LIBRARY}
-  ${SDL2_IMAGE_LIBRARY}
+  SDL2::SDL2
 )
+
+if(TARGET SDL2_ttf::SDL2_ttf)
+  target_link_libraries(pokemoncollection_sim PRIVATE SDL2_ttf::SDL2_ttf)
+else()
+  target_link_libraries(pokemoncollection_sim PRIVATE ${SDL2_TTF_LIBRARY})
+endif()
+
+if(TARGET SDL2_image::SDL2_image)
+  target_link_libraries(pokemoncollection_sim PRIVATE SDL2_image::SDL2_image)
+else()
+  target_link_libraries(pokemoncollection_sim PRIVATE ${SDL2_IMAGE_LIBRARY})
+endif()

--- a/sim/CMakePresets.json
+++ b/sim/CMakePresets.json
@@ -1,0 +1,43 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "sim default",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "macos-arm64",
+      "displayName": "sim macOS arm64",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build-arm64",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "arm64"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "macos-arm64",
+      "configurePreset": "macos-arm64"
+    }
+  ]
+}

--- a/sim/README.md
+++ b/sim/README.md
@@ -21,9 +21,56 @@
 
 ```bash
 cd sim
+./bootstrap.sh
 cmake -S . -B build
 cmake --build build
 ./build/pokemoncollection_sim
+```
+
+preset を使う場合:
+
+```bash
+cd sim
+./bootstrap.sh default
+cmake --build --preset default
+./build/pokemoncollection_sim
+```
+
+`ArduinoJson` は次の順で解決されます。
+
+1. `sim/local-deps/ArduinoJson`
+2. `pio run -e m5stack-cores3` で展開された `.pio/libdeps/.../ArduinoJson/src`
+3. `ARDUINOJSON_ROOT` で指定したローカル配置先
+4. CMake `FetchContent` による自動取得
+
+ネットワークを使わずにビルドしたい場合は、`ArduinoJson` の配置先を明示してください。
+
+```bash
+ARDUINOJSON_ROOT=/path/to/ArduinoJson ./bootstrap.sh default
+```
+
+`bootstrap.sh` は外部の `ArduinoJson` を見つけたら `sim/local-deps/ArduinoJson` にコピーして、次回以降はそのローカルキャッシュを優先利用します。
+
+Apple Silicon で既存の `build` ディレクトリが `x86_64` 向けに作られている場合は、別ディレクトリで作り直してください。
+
+```bash
+./bootstrap.sh macos-arm64
+cmake --build --preset macos-arm64
+./build-arm64/pokemoncollection_sim
+```
+
+必要な依存:
+
+- `cmake`
+- `sdl2`
+- `sdl2_image`
+- `sdl2_ttf`
+- `ArduinoJson` のローカル配置、またはネットワーク経由の自動取得
+
+macOS + Homebrew なら最低限これで揃います。
+
+```bash
+brew install cmake sdl2 sdl2_image sdl2_ttf
 ```
 
 今後の予定:

--- a/sim/bootstrap.sh
+++ b/sim/bootstrap.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PRESET="${1:-}"
+LOCAL_DEPS_DIR="$SCRIPT_DIR/local-deps"
+LOCAL_ARDUINOJSON_DIR="$LOCAL_DEPS_DIR/ArduinoJson"
+
+if [[ -z "$PRESET" ]]; then
+  if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+    PRESET="macos-arm64"
+  else
+    PRESET="default"
+  fi
+fi
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "'$1' is required"
+}
+
+need_cmd cmake
+
+if [[ "$PRESET" == "macos-arm64" ]]; then
+  need_cmd brew
+  for pkg in sdl2 sdl2_image sdl2_ttf; do
+    if [[ ! -d "/opt/homebrew/opt/$pkg" ]]; then
+      die "Homebrew package '$pkg' is missing. Run: brew install cmake sdl2 sdl2_image sdl2_ttf"
+    fi
+  done
+fi
+
+resolve_arduinojson_dir() {
+  local candidate="$1"
+  if [[ -z "$candidate" ]]; then
+    return 1
+  fi
+  if [[ -f "$candidate/src/ArduinoJson.h" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [[ -f "$candidate/ArduinoJson.h" ]]; then
+    printf '%s\n' "$(cd "$candidate/.." && pwd)"
+    return 0
+  fi
+  return 1
+}
+
+copy_arduinojson_into_local_deps() {
+  local source_dir="$1"
+  mkdir -p "$LOCAL_DEPS_DIR"
+  rm -rf "$LOCAL_ARDUINOJSON_DIR"
+  cp -R "$source_dir" "$LOCAL_ARDUINOJSON_DIR"
+  printf '%s\n' "$LOCAL_ARDUINOJSON_DIR"
+}
+
+find_arduinojson_root() {
+  local resolved=""
+  if [[ -n "${ARDUINOJSON_ROOT:-}" ]]; then
+    if resolved="$(resolve_arduinojson_dir "${ARDUINOJSON_ROOT}")"; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+    die "ARDUINOJSON_ROOT is set, but ArduinoJson.h was not found under '$ARDUINOJSON_ROOT'"
+  fi
+
+  if resolved="$(resolve_arduinojson_dir "$LOCAL_ARDUINOJSON_DIR")"; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  local candidate
+  for candidate in \
+    "$SCRIPT_DIR/../.pio/libdeps"/*/ArduinoJson \
+    "$HOME/.platformio/lib/ArduinoJson" \
+    "$HOME/Documents/Arduino/libraries/ArduinoJson" \
+    "/tmp/ArduinoJson"
+  do
+    if resolved="$(resolve_arduinojson_dir "$candidate")"; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+ARDUINOJSON_ROOT_VALUE=""
+if ARDUINOJSON_ROOT_VALUE="$(find_arduinojson_root)"; then
+  if [[ "$ARDUINOJSON_ROOT_VALUE" != "$LOCAL_ARDUINOJSON_DIR" ]]; then
+    echo "Caching ArduinoJson into: $LOCAL_ARDUINOJSON_DIR"
+    ARDUINOJSON_ROOT_VALUE="$(copy_arduinojson_into_local_deps "$ARDUINOJSON_ROOT_VALUE")"
+  fi
+  echo "Using ArduinoJson from: $ARDUINOJSON_ROOT_VALUE"
+  cmake --preset "$PRESET" -DARDUINOJSON_ROOT="$ARDUINOJSON_ROOT_VALUE"
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+error: ArduinoJson was not found locally.
+
+Do one of the following, then rerun this script:
+  1. Export ARDUINOJSON_ROOT=/path/to/ArduinoJson
+  2. Run `pio run -e m5stack-cores3` once to populate .pio/libdeps
+  3. Re-run CMake directly with network access so FetchContent can download ArduinoJson
+EOF
+exit 1


### PR DESCRIPTION
## What changed
- made the simulator CMake setup resolve `ArduinoJson` from local cache, PlatformIO libdeps, explicit roots, or `FetchContent`
- added `sim/bootstrap.sh` and `sim/CMakePresets.json` so simulator configure/build is reproducible on macOS Apple Silicon
- improved `SDL2` / `SDL2_image` / `SDL2_ttf` dependency detection and added clearer setup notes to `sim/README.md`
- ignored generated `sim/build-*` and `sim/local-deps/` directories and recorded the progress in `docs/issues.md`

## Why
The simulator could build only when a specific local dependency layout already existed. It also failed easily on Apple Silicon because stale `x86_64` build directories and missing dependency hints were not handled well.

## Impact
- simulator setup is easier to reproduce on a fresh machine
- offline rebuilds work after the first local `ArduinoJson` cache is created
- missing SDL dependencies fail with actionable messages instead of vague link errors

## Validation
- `./bootstrap.sh macos-arm64`
- `cmake --build --preset macos-arm64`
- confirmed the simulator binary launches after the build